### PR TITLE
chat history options

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,8 @@ loom {
         runDirectory = rootProject.file("run")
         jvmArguments.add("-Dmixin.debug.export=true")
     }
+
+    runConfigs.remove(runConfigs["server"])
 }
 
 java {

--- a/src/main/java/org/polyfrost/chattweaks/config/ChatTweaksConfig.java
+++ b/src/main/java/org/polyfrost/chattweaks/config/ChatTweaksConfig.java
@@ -30,16 +30,18 @@ public class ChatTweaksConfig extends Config {
     )
     public boolean removeBlankMessages = false;
 
-    @Switch(
+    @Slider(
             title = "Increase Chat History Limit",
-            description = "Increase the 100 message cap on chat limit history to 1000 messages.",
-            subcategory = "History"
+            description = "Increase the 100 message cap on chat limit history to a custom amount.",
+            subcategory = "History",
+            min = 100,
+            max = 16384
     )
-    public boolean increaseChatHistoryLimit = true;
+    public int increaseChatHistoryLimit = 1000;
 
     @Switch(
             title = "Don't Clear Chat History",
-            description = "Skip clearing the chat history when disconnecting from a world.",
+            description = "Skip clearing chat history when disconnecting from a world.",
             subcategory = "History"
     )
     public boolean dontClearChatHistory = true;

--- a/src/main/java/org/polyfrost/chattweaks/config/ChatTweaksConfig.java
+++ b/src/main/java/org/polyfrost/chattweaks/config/ChatTweaksConfig.java
@@ -32,7 +32,7 @@ public class ChatTweaksConfig extends Config {
 
     @Switch(
             title = "Increase Chat History Limit",
-            description = "Increase the 100 cap on chat limit history.",
+            description = "Increase the 100 message cap on chat limit history to 1000 messages.",
             subcategory = "History"
     )
     public boolean increaseChatHistoryLimit = true;

--- a/src/main/java/org/polyfrost/chattweaks/config/ChatTweaksConfig.java
+++ b/src/main/java/org/polyfrost/chattweaks/config/ChatTweaksConfig.java
@@ -30,6 +30,19 @@ public class ChatTweaksConfig extends Config {
     )
     public boolean removeBlankMessages = false;
 
+    @Switch(
+            title = "Increase Chat History Limit",
+            description = "Increase the 100 cap on chat limit history.",
+            subcategory = "History"
+    )
+    public boolean increaseChatHistoryLimit = true;
+
+    @Switch(
+            title = "Don't Clear Chat History",
+            description = "Skip clearing the chat history when disconnecting from a world.",
+            subcategory = "History"
+    )
+    public boolean dontClearChatHistory = true;
 
     @Switch(
             title = "Compact Chat",

--- a/src/main/java/org/polyfrost/chattweaks/features/ImagePreview.java
+++ b/src/main/java/org/polyfrost/chattweaks/features/ImagePreview.java
@@ -5,12 +5,12 @@ import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.ChatComponent;
 //? if <26.1 {
-import net.minecraft.client.gui.GuiGraphics;
-//?} else {
-/*import net.minecraft.client.gui.GuiGraphicsExtractor;
-*///?}
+/*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+//?}
 import net.minecraft.client.renderer.texture.DynamicTexture;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.lwjgl.glfw.GLFW;
 import org.polyfrost.chattweaks.ChatTweaks;
 import org.polyfrost.chattweaks.util.ChatCompat;
@@ -34,7 +34,7 @@ public final class ImagePreview {
 
     private static volatile NativeImage pendingImage;
     private static String loaded;
-    private static ResourceLocation texture;
+    private static Identifier texture;
     private static int imageWidth = 100;
     private static int imageHeight = 100;
 
@@ -42,10 +42,10 @@ public final class ImagePreview {
     // GuiGraphicsExtractor. Both expose the same blit(RenderPipeline, ...) overload,
     // so only the parameter type differs (see GuiMixin for the matching hooks).
     //? if <26.1 {
-    public static void render(GuiGraphics graphics) {
-    //?} else {
-    /*public static void render(GuiGraphicsExtractor graphics) {
-    *///?}
+    /*public static void render(GuiGraphics graphics) {
+    *///?} else {
+    public static void render(GuiGraphicsExtractor graphics) {
+    //?}
         if (!ChatTweaks.config.imagePreview) {
             return;
         }
@@ -55,10 +55,10 @@ public final class ImagePreview {
         double mouseY = mc.mouseHandler.ypos() * window.getGuiScaledHeight() / Math.max(1, window.getScreenHeight());
 
         //? if <26.2 {
-        ChatComponent chat = mc.gui.getChat();
-        //?} else {
-        /*ChatComponent chat = mc.gui.hud.getChat();
-        *///?}
+        /*ChatComponent chat = mc.gui.getChat();
+        *///?} else {
+        ChatComponent chat = mc.gui.hud.getChat();
+        //?}
         String url = ((HoveredUrl) chat).chattweaks$hoveredUrl(mouseX, mouseY);
         if (url == null) {
             releaseTexture(mc);
@@ -69,10 +69,10 @@ public final class ImagePreview {
     }
 
     //? if <26.1 {
-    private static void handle(Minecraft mc, GuiGraphics graphics, String value) {
-    //?} else {
-    /*private static void handle(Minecraft mc, GuiGraphicsExtractor graphics, String value) {
-    *///?}
+    /*private static void handle(Minecraft mc, GuiGraphics graphics, String value) {
+    *///?} else {
+    private static void handle(Minecraft mc, GuiGraphicsExtractor graphics, String value) {
+    //?}
         if (!value.startsWith("http")) {
             releaseTexture(mc);
             return;
@@ -99,7 +99,7 @@ public final class ImagePreview {
             //?} else {
             /*DynamicTexture dynamicTexture = new DynamicTexture(image);
             *///?}
-            texture = ResourceLocation.fromNamespaceAndPath("chattweaks", "preview");
+            texture = Identifier.fromNamespaceAndPath("chattweaks", "preview");
             mc.getTextureManager().register(texture, dynamicTexture);
             imageWidth = image.getWidth();
             imageHeight = image.getHeight();
@@ -130,8 +130,8 @@ public final class ImagePreview {
         // On 26.1+ the extractor batches draws per stratum; advance to a fresh one so the
         // preview lands on top of the rest of the HUD instead of behind it.
         //? if >=26.1 {
-        /*graphics.nextStratum();
-        *///?}
+        graphics.nextStratum();
+        //?}
 
         //? if >=1.21.8 {
         graphics.blit(net.minecraft.client.renderer.RenderPipelines.GUI_TEXTURED, texture, 0, 0, 0F, 0F, (int) drawWidth, (int) drawHeight, imageWidth, imageHeight, imageWidth, imageHeight);

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
@@ -70,11 +70,11 @@ public abstract class ChatComponentMixin {
     @Shadow
     @Final
     @Mutable
-    private ArrayListDeque<String> recentChat = new ArrayListDeque<>(1000);
+    private ArrayListDeque<String> recentChat = new ArrayListDeque<>(ChatTweaks.config.increaseChatHistoryLimit);
 
     @ModifyExpressionValue(method = {"addMessageToDisplayQueue", "addMessageToQueue", "addRecentChat"}, at = @At(value = "CONSTANT", args = "intValue=100"))
     public int chattweaks$increaseChatHistoryLimit(int original) {
-        return ChatTweaks.config.increaseChatHistoryLimit ? 1000 : original;
+        return ChatTweaks.config.increaseChatHistoryLimit;
     }
 
     @Unique

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
@@ -70,11 +70,11 @@ public abstract class ChatComponentMixin {
     @Shadow
     @Final
     @Mutable
-    private ArrayListDeque<String> recentChat = new ArrayListDeque<>(100);
+    private ArrayListDeque<String> recentChat = new ArrayListDeque<>(1000);
 
     @ModifyExpressionValue(method = {"addMessageToDisplayQueue", "addMessageToQueue", "addRecentChat"}, at = @At(value = "CONSTANT", args = "intValue=100"))
     public int chattweaks$increaseChatHistoryLimit(int original) {
-        return ChatTweaks.config.increaseChatHistoryLimit ? Integer.MAX_VALUE : original;
+        return ChatTweaks.config.increaseChatHistoryLimit ? 1000 : original;
     }
 
     @Unique

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
@@ -9,7 +9,6 @@ import net.minecraft.network.chat.MessageSignature;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
-import net.minecraft.util.ArrayListDeque;
 import org.polyfrost.chattweaks.ChatTweaks;
 import org.polyfrost.chattweaks.util.ChatCompat;
 import org.polyfrost.chattweaks.util.ChatUtils;
@@ -66,14 +65,8 @@ public abstract class ChatComponentMixin {
     }
     *///?}
 
-    @SuppressWarnings("unused")
-    @Shadow
-    @Final
-    @Mutable
-    private ArrayListDeque<String> recentChat = new ArrayListDeque<>(ChatTweaks.config.increaseChatHistoryLimit);
-
-    @ModifyExpressionValue(method = {"addMessageToDisplayQueue", "addMessageToQueue", "addRecentChat"}, at = @At(value = "CONSTANT", args = "intValue=100"))
-    public int chattweaks$increaseChatHistoryLimit(int original) {
+    @ModifyExpressionValue(method = {"addMessageToDisplayQueue", "addMessageToQueue"}, at = @At(value = "CONSTANT", args = "intValue=100"), require = 2, allow = 2)
+    private int chattweaks$increaseChatHistoryLimit(int original) {
         return ChatTweaks.config.increaseChatHistoryLimit;
     }
 

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
@@ -1,12 +1,6 @@
 package org.polyfrost.chattweaks.mixins;
 
-//? if >=26.1 {
-import net.minecraft.client.multiplayer.chat.GuiMessage;
-import net.minecraft.client.multiplayer.chat.GuiMessageTag;
-//?} else {
-/*import net.minecraft.client.GuiMessage;
-import net.minecraft.client.GuiMessageTag;
-*///?}
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.components.ChatComponent;
@@ -15,13 +9,11 @@ import net.minecraft.network.chat.MessageSignature;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
+import net.minecraft.util.ArrayListDeque;
 import org.polyfrost.chattweaks.ChatTweaks;
 import org.polyfrost.chattweaks.util.ChatCompat;
 import org.polyfrost.chattweaks.util.ChatUtils;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -29,6 +21,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+//? if >=26.1 {
+import net.minecraft.client.multiplayer.chat.GuiMessage;
+import net.minecraft.client.multiplayer.chat.GuiMessageTag;
+//?} else {
+/*import net.minecraft.client.GuiMessage;
+import net.minecraft.client.GuiMessageTag;
+*///?}
 
 @Mixin(ChatComponent.class)
 public abstract class ChatComponentMixin {
@@ -53,7 +53,7 @@ public abstract class ChatComponentMixin {
     protected abstract void refreshTrimmedMessages();
 
     //? if >=26.1 {
-    
+
     @Inject(method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V", at = @At("HEAD"), cancellable = true)
     private void chattweaks$onAddMessage(Component component, MessageSignature signature, net.minecraft.client.multiplayer.chat.GuiMessageSource source, GuiMessageTag tag, CallbackInfo ci) {
         chattweaks$handleAdd(component, signature, source, tag, ci);
@@ -65,6 +65,17 @@ public abstract class ChatComponentMixin {
         chattweaks$handleAdd(component, signature, null, tag, ci);
     }
     *///?}
+
+    @SuppressWarnings("unused")
+    @Shadow
+    @Final
+    @Mutable
+    private ArrayListDeque<String> recentChat = new ArrayListDeque<>(100);
+
+    @ModifyExpressionValue(method = {"addMessageToDisplayQueue", "addMessageToQueue", "addRecentChat"}, at = @At(value = "CONSTANT", args = "intValue=100"))
+    public int chattweaks$increaseChatHistoryLimit(int original) {
+        return ChatTweaks.config.increaseChatHistoryLimit ? Integer.MAX_VALUE : original;
+    }
 
     @Unique
     private void chattweaks$handleAdd(Component component, MessageSignature signature, Object source, Object tag, CallbackInfo ci) {

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ChatComponentMixin.java
@@ -1,12 +1,12 @@
 package org.polyfrost.chattweaks.mixins;
 
 //? if >=26.1 {
-/*import net.minecraft.client.multiplayer.chat.GuiMessage;
+import net.minecraft.client.multiplayer.chat.GuiMessage;
 import net.minecraft.client.multiplayer.chat.GuiMessageTag;
-*///?} else {
-import net.minecraft.client.GuiMessage;
+//?} else {
+/*import net.minecraft.client.GuiMessage;
 import net.minecraft.client.GuiMessageTag;
-//?}
+*///?}
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.components.ChatComponent;
@@ -41,10 +41,10 @@ public abstract class ChatComponentMixin {
     private static String chattweaks$lastStamp = "";
 
     //? if >=26.1 {
-    /*@Shadow
+    @Shadow
     private void addMessage(Component component, MessageSignature signature, net.minecraft.client.multiplayer.chat.GuiMessageSource source, GuiMessageTag tag) {
     }
-    *///?}
+    //?}
     @Shadow
     @Final
     private List<GuiMessage> allMessages;
@@ -53,18 +53,18 @@ public abstract class ChatComponentMixin {
     protected abstract void refreshTrimmedMessages();
 
     //? if >=26.1 {
-    /*
+    
     @Inject(method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V", at = @At("HEAD"), cancellable = true)
     private void chattweaks$onAddMessage(Component component, MessageSignature signature, net.minecraft.client.multiplayer.chat.GuiMessageSource source, GuiMessageTag tag, CallbackInfo ci) {
         chattweaks$handleAdd(component, signature, source, tag, ci);
     }
-    */
+    
     //?} else {
-    @Inject(method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V", at = @At("HEAD"), cancellable = true)
+    /*@Inject(method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V", at = @At("HEAD"), cancellable = true)
     private void chattweaks$onAddMessage(Component component, MessageSignature signature, GuiMessageTag tag, CallbackInfo ci) {
         chattweaks$handleAdd(component, signature, null, tag, ci);
     }
-    //?}
+    *///?}
 
     @Unique
     private void chattweaks$handleAdd(Component component, MessageSignature signature, Object source, Object tag, CallbackInfo ci) {
@@ -97,10 +97,10 @@ public abstract class ChatComponentMixin {
     @Unique
     private void chattweaks$dispatch(Component component, MessageSignature signature, Object source, Object tag) {
         //? if >=26.1 {
-        /*this.addMessage(component, signature, (net.minecraft.client.multiplayer.chat.GuiMessageSource) source, (GuiMessageTag) tag);
-         *///?} else {
-        ((ChatComponent) (Object) this).addMessage(component, signature, (GuiMessageTag) tag);
-        //?}
+        this.addMessage(component, signature, (net.minecraft.client.multiplayer.chat.GuiMessageSource) source, (GuiMessageTag) tag);
+         //?} else {
+        /*((ChatComponent) (Object) this).addMessage(component, signature, (GuiMessageTag) tag);
+        *///?}
     }
 
     @Unique

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ChatHoverMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ChatHoverMixin.java
@@ -1,10 +1,10 @@
 package org.polyfrost.chattweaks.mixins;
 
 //? if >=26.1 {
-/*import net.minecraft.client.multiplayer.chat.GuiMessage;
-*///?} else {
-import net.minecraft.client.GuiMessage;
-//?}
+import net.minecraft.client.multiplayer.chat.GuiMessage;
+//?} else {
+/*import net.minecraft.client.GuiMessage;
+*///?}
 import net.minecraft.client.gui.components.ChatComponent;
 import org.jetbrains.annotations.Nullable;
 import org.polyfrost.chattweaks.util.HoveredUrl;
@@ -24,7 +24,7 @@ public abstract class ChatHoverMixin implements HoveredUrl {
     private static final Pattern chattweaks$URL = Pattern.compile("https?://\\S+");
 
     //? if <1.21.11 {
-    @Shadow
+    /*@Shadow
     @Final
     private List<GuiMessage.Line> trimmedMessages;
 
@@ -42,7 +42,7 @@ public abstract class ChatHoverMixin implements HoveredUrl {
     private int getMessageLineIndexAt(double d, double e) {
         return 0;
     }
-    //?} elif <26.1 {
+    *///?} elif <26.1 {
     /*@Shadow
     @Final
     private List<GuiMessage.Line> trimmedMessages;
@@ -109,7 +109,7 @@ public abstract class ChatHoverMixin implements HoveredUrl {
         return -1;
     }
     *///?} else {
-    /*@Shadow
+    @Shadow
     @Final
     private List<GuiMessage.Line> trimmedMessages;
 
@@ -169,13 +169,13 @@ public abstract class ChatHoverMixin implements HoveredUrl {
         }
         return -1;
     }
-    *///?}
+    //?}
 
     @Override
     @Nullable
     public String chattweaks$hoveredUrl(double mouseX, double mouseY) {
         //? if <1.21.11 {
-        double chatX = screenToChatX(mouseX);
+        /*double chatX = screenToChatX(mouseX);
         double chatY = screenToChatY(mouseY);
         int index = getMessageLineIndexAt(chatX, chatY);
         if (index < 0 || index >= trimmedMessages.size()) {
@@ -190,7 +190,7 @@ public abstract class ChatHoverMixin implements HoveredUrl {
 
         Matcher matcher = chattweaks$URL.matcher(line.toString());
         return matcher.find() ? matcher.group() : null;
-        //?} elif <26.1 {
+        *///?} elif <26.1 {
         /*double chatX = chattweaks$screenToChatX(mouseX);
         double chatY = chattweaks$screenToChatY(mouseY);
         int index = chattweaks$getMessageLineIndexAt(chatX, chatY);
@@ -207,7 +207,7 @@ public abstract class ChatHoverMixin implements HoveredUrl {
         Matcher matcher = chattweaks$URL.matcher(line.toString());
         return matcher.find() ? matcher.group() : null;
         *///?} else {
-        /*double chatX = chattweaks$screenToChatX(mouseX);
+        double chatX = chattweaks$screenToChatX(mouseX);
         double chatY = chattweaks$screenToChatY(mouseY);
         int index = chattweaks$getMessageLineIndexAt(chatX, chatY);
         if (index < 0 || index >= trimmedMessages.size()) {
@@ -222,6 +222,6 @@ public abstract class ChatHoverMixin implements HoveredUrl {
 
         Matcher matcher = chattweaks$URL.matcher(line.toString());
         return matcher.find() ? matcher.group() : null;
-        *///?}
+        //?}
     }
 }

--- a/src/main/java/org/polyfrost/chattweaks/mixins/GuiMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/GuiMixin.java
@@ -1,5 +1,6 @@
 package org.polyfrost.chattweaks.mixins;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import net.minecraft.client.DeltaTracker;
 //? if <26.2 {
 /*import net.minecraft.client.gui.Gui;
@@ -11,6 +12,8 @@ import net.minecraft.client.gui.Hud;
 *///?} else {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 //?}
+import net.minecraft.client.gui.components.ChatComponent;
+import org.polyfrost.chattweaks.ChatTweaks;
 import org.polyfrost.chattweaks.features.ImagePreview;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -37,4 +40,9 @@ public class GuiMixin {
         ImagePreview.render(guiGraphics);
     }
     //?}
+
+    @WrapWithCondition(method = "onDisconnected", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/ChatComponent;clearMessages(Z)V"))
+    private boolean chattweaks$clearChatHistory(ChatComponent instance, boolean bl) {
+        return !ChatTweaks.config.dontClearChatHistory;
+    }
 }

--- a/src/main/java/org/polyfrost/chattweaks/mixins/GuiMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/GuiMixin.java
@@ -2,15 +2,15 @@ package org.polyfrost.chattweaks.mixins;
 
 import net.minecraft.client.DeltaTracker;
 //? if <26.2 {
-import net.minecraft.client.gui.Gui;
-//?} else {
-/*import net.minecraft.client.gui.Hud;
-*///?}
+/*import net.minecraft.client.gui.Gui;
+*///?} else {
+import net.minecraft.client.gui.Hud;
+//?}
 //? if <26.1 {
-import net.minecraft.client.gui.GuiGraphics;
-//?} else {
-/*import net.minecraft.client.gui.GuiGraphicsExtractor;
-*///?}
+/*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+//?}
 import org.polyfrost.chattweaks.features.ImagePreview;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -21,20 +21,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 // 26.1:  deferred render-state extractor, hook Gui#extractRenderState.
 // 26.2+: HUD split out of Gui, hook Hud#extractRenderState.
 //? if <26.2 {
-@Mixin(Gui.class)
-//?} else {
-/*@Mixin(Hud.class)
-*///?}
+/*@Mixin(Gui.class)
+*///?} else {
+@Mixin(Hud.class)
+//?}
 public class GuiMixin {
     //? if <26.1 {
-    @Inject(method = "render", at = @At("TAIL"))
+    /*@Inject(method = "render", at = @At("TAIL"))
     private void chattweaks$renderImagePreview(GuiGraphics guiGraphics, DeltaTracker deltaTracker, CallbackInfo ci) {
         ImagePreview.render(guiGraphics);
     }
-    //?} else {
-    /*@Inject(method = "extractRenderState", at = @At("TAIL"))
+    *///?} else {
+    @Inject(method = "extractRenderState", at = @At("TAIL"))
     private void chattweaks$renderImagePreview(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker, CallbackInfo ci) {
         ImagePreview.render(guiGraphics);
     }
-    *///?}
+    //?}
 }

--- a/src/main/java/org/polyfrost/chattweaks/mixins/ScreenMixin.java
+++ b/src/main/java/org/polyfrost/chattweaks/mixins/ScreenMixin.java
@@ -18,17 +18,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class ScreenMixin {
 
     //? if >=1.21.11 {
-    //@Inject(method = "defaultHandleGameClickEvent", at = @At("HEAD"))
-    //private static void chattweaks$safeChatClicksHistory(ClickEvent clickEvent, Minecraft minecraft, Screen screen, CallbackInfo ci) {
-    //    if (!ChatTweaks.config.safeChatClicksHistory || !(screen instanceof ChatScreen) || clickEvent == null) {
-    //        return;
-    //    }
-    //    if (ChatCompat.isRunCommand(clickEvent)) {
-    //        ChatCompat.addRecentChat(ChatCompat.safeClickValue(clickEvent));
-    //    }
-    //}
+    @Inject(method = "defaultHandleGameClickEvent", at = @At("HEAD"))
+    private static void chattweaks$safeChatClicksHistory(ClickEvent clickEvent, Minecraft minecraft, Screen screen, CallbackInfo ci) {
+        if (!ChatTweaks.config.safeChatClicksHistory || !(screen instanceof ChatScreen) || clickEvent == null) {
+            return;
+        }
+        if (ChatCompat.isRunCommand(clickEvent)) {
+            ChatCompat.addRecentChat(ChatCompat.safeClickValue(clickEvent));
+        }
+    }
     //?} else {
-    @Inject(method = "handleComponentClicked", at = @At("HEAD"))
+    /*@Inject(method = "handleComponentClicked", at = @At("HEAD"))
     private void chattweaks$safeChatClicksHistory(@Nullable Style style, CallbackInfoReturnable<Boolean> cir) {
         if (!ChatTweaks.config.safeChatClicksHistory || style == null || !((Object) this instanceof ChatScreen)) {
             return;
@@ -38,5 +38,5 @@ public abstract class ScreenMixin {
             ChatCompat.addRecentChat(ChatCompat.safeClickValue(clickEvent));
         }
     }
-    //?}
+    *///?}
 }

--- a/src/main/java/org/polyfrost/chattweaks/util/ChatCompat.java
+++ b/src/main/java/org/polyfrost/chattweaks/util/ChatCompat.java
@@ -74,18 +74,18 @@ public final class ChatCompat {
     public static void addRecentChat(String command) {
         Minecraft mc = Minecraft.getInstance();
         //? if >=26.2 {
-        /*mc.gui.hud.getChat().addRecentChat(command);
-        *///?} else {
-        mc.gui.getChat().addRecentChat(command);
-        //?}
+        mc.gui.hud.getChat().addRecentChat(command);
+        //?} else {
+        /*mc.gui.getChat().addRecentChat(command);
+        *///?}
     }
 
     @Nullable
     public static Style hoveredChatStyle(double mouseX, double mouseY) {
         //? if >=1.21.11 {
-        /*return null;
-        *///?} else {
-        return Minecraft.getInstance().gui.getChat().getClickedComponentStyleAt(mouseX, mouseY);
-        //?}
+        return null;
+        //?} else {
+        /*return Minecraft.getInstance().gui.getChat().getClickedComponentStyleAt(mouseX, mouseY);
+        *///?}
     }
 }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("dev.kikugie.stonecutter")
 }
 
-stonecutter active "1.21.10"
+stonecutter active "26.2"
 
 stonecutter parameters {
     swaps["mod_version"] = "\"${property("mod.version")}\";"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
someone forgot to reset vcs so i kept a single commit for that so the real diff would be easier to view

adds chat history options similar to what existed in patcher. i kept the max length to 1000 due to possible performance issues that had occurred around skyblock mods. easy to change if needed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #17 & #18

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add Increase Chat History Limit
Add Don't Clear Chat History
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->